### PR TITLE
Fix FMUL, FMULS and FMULSU disassembly

### DIFF
--- a/avrasmgen.c
+++ b/avrasmgen.c
@@ -1535,11 +1535,11 @@ void emitavrasm(struct wordlist *wl, struct regionstruct *enaregs, int listing)
             else
                 printf("clr r%d\n", d);
         else if (fmul(wl->word, &d, &r))
-            printf("fmul r%d, r%d\n", d+16, r);
+            printf("fmul r%d, r%d\n", d+16, r+16);
         else if (fmuls(wl->word, &d, &r))
-            printf("fmuls r%d, r%d\n", d+16, r);
+            printf("fmuls r%d, r%d\n", d+16, r+16);
         else if (fmulsu(wl->word, &d, &r))
-            printf("fmulsu r%d, r%d\n", d+16, r);
+            printf("fmulsu r%d, r%d\n", d+16, r+16);
         else if (wl->word == 0x9509)
             printf("icall\n");
         else if (ijmp(wl->word))


### PR DESCRIPTION
Fixed the FMUL, FMULS and FMULSU instructions disassembly.

According to the AVR CPU Instruction Set Manual, the operands for the instructions FMUL, FMULS and FMULSU are two registers, each one of those ranging from R16 to R23 `(16 ≤ d ≤ 23, 16 ≤ r ≤ 23)`. The first operand was being correctly disassembled, but the second one was being subtracted 16 from its real value.